### PR TITLE
Fix the dtInterval adjunstment on output time using adaptive and 

### DIFF
--- a/dyn_em/adapt_timestep_em.F
+++ b/dyn_em/adapt_timestep_em.F
@@ -288,7 +288,7 @@ RECURSIVE SUBROUTINE adapt_timestep(grid, config_flags)
   den = precision
   CALL WRFU_TimeIntervalSet(tmpTimeInterval, Sn=num, Sd=den)
 
-if (num .LE. 0) then
+  if (num .LE. 0) then
      stepping_to_bc = .false.
   elseif ( ( tmpTimeInterval .LT. dtInterval * 2 ) .and. &
        ( tmpTimeInterval .GT. dtInterval ) ) then
@@ -327,34 +327,26 @@ if (num .LE. 0) then
      history_interval_sec = grid%history_interval_s + grid%history_interval_m*60 + &
                             grid%history_interval_h*3600 + grid%history_interval_d*86400
 
-     time_to_output = history_interval_sec - &
-          mod( curr_secs, REAL(history_interval_sec) )
-     num = INT(time_to_output * precision + 0.5)
+     num = INT(history_interval_sec * precision + 0.5)
      den = precision
-     call WRFU_TimeIntervalSet(tmpTimeInterval, Sn=num, Sd=den)
+     CALL WRFU_TimeIntervalSet(tmpTimeInterval, Sn=num, Sd=den)
+
+     !Calc the time to output
+     tmpTimeInterval = tmpTimeInterval * (INT(curr_secs / REAL(history_interval_sec))+1) - &
+                      (domain_get_current_time ( grid ) - domain_get_start_time ( grid ) )
 
      if ( ( tmpTimeInterval .LT. dtInterval * 2 ) .and. &
           ( tmpTimeInterval .GT. dtInterval ) ) then
-        dtInterval = tmpTimeInterval / 2
+        
+        num = INT(( real_time(tmpTimeInterval) * precision)/2 + 0.5)
+        den = precision
+        call WRFU_TimeIntervalSet(dtInterval, Sn=num, Sd=den)
+
         use_last2 = .TRUE.
         grid%stepping_to_time = .TRUE.
 
      elseif (tmpTimeInterval .LE. dtInterval) then
-        !
-        ! We will do some tricks here to assure that we fall exactly on an 
-        !   output time.  Without the tricks, round-off error causes problems!
-        !
-
-        !
-        ! Calculate output time.  We round to nearest history time to assure 
-        !    we don't have any rounding error.
-        !
-        output_time = NINT ( (curr_secs + time_to_output) /  &
-             (history_interval_sec) ) * (history_interval_sec)
-        CALL WRFU_TimeIntervalSet(tmpTimeInterval, S=output_time)
-        dtInterval = tmpTimeInterval - &
-             (domain_get_current_time(grid) - domain_get_start_time(grid))
-
+        dtInterval = tmpTimeInterval
         use_last2 = .TRUE.
         grid%stepping_to_time = .TRUE.
      endif


### PR DESCRIPTION
Problems with the precision of the time_to_output calculation cause errors in setting the correct time step at output time and final time in the em_b_wave ideal test (After removing the same mitigation code)

TYPE: bug fix

KEYWORDS: 5 to 10 words related to commit, separated by commas

SOURCE: Either "developer's name (affiliation)" .XOR. "internal" for a WRF Dev committee member

DESCRIPTION OF CHANGES:
Problem:
For the time_to_output calculation, the current simulation time is used as a float. This sometimes causes the time_to_output to be inaccurate, leading to problems, especially at the end of the simulation."

Solution:
I determinate the time_to_output  using the current simulation time in TimeInterval type, avoiding the numeric.

ISSUE: 
#2103

LIST OF MODIFIED FILES: 
/dyn_em/adapt_timestep_em.F


TESTS CONDUCTED: 

RELEASE NOTE: Corrected source o problems realted to
